### PR TITLE
Include commit messages from submodules when bumping

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Apply Patches", func() {
 			Expect(session.Out).To(gbytes.Say("On branch 1.7.13"))
 			Expect(session.Out).To(gbytes.Say("nothing to commit"))
 
-			command = exec.Command("git", "log", "--pretty=format:%s", "-n", "10")
+			command = exec.Command("git", "log", "--pretty=format:%B", "-n", "13")
 			command.Dir = releaseRepo
 			session, err = gexec.Start(command, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
@@ -56,6 +56,9 @@ var _ = Describe("Apply Patches", func() {
 			Eventually(session).Should(gexec.Exit(0))
 			Expect(session.Out).To(gbytes.Say(`Knit patch of src/loggregator`))
 			Expect(session.Out).To(gbytes.Say(`Knit bump of src/uaa-release`))
+			Expect(session.Out).To(gbytes.Say(`Submodule src/uaa-release`))
+			Expect(session.Out).To(gbytes.Say(`> Create final release 11.3`))
+			Expect(session.Out).To(gbytes.Say(`> Bump UAA to 3.3.0.3`))
 			Expect(session.Out).To(gbytes.Say(`Knit patch of src/capi-release/src/cloud_controller_ng`))
 			Expect(session.Out).To(gbytes.Say(`Knit patch of src/capi-release/src/cloud_controller_ng`))
 			Expect(session.Out).To(gbytes.Say(`Knit bump of src/consul-release`))
@@ -64,6 +67,11 @@ var _ = Describe("Apply Patches", func() {
 			Expect(session.Out).To(gbytes.Say(`Knit patch of src/capi-release/src/cloud_controller_ng`))
 			Expect(session.Out).To(gbytes.Say(`Knit patch of src/capi-release`))
 			Expect(session.Out).To(gbytes.Say(`Update nginx to 1.11.1`))
+			Expect(session.Out).To(gbytes.Say(`Knit patch of src/loggregator`))
+			Expect(session.Out).To(gbytes.Say(`Knit patch of src/loggregator`))
+			Expect(session.Out).To(gbytes.Say(`Knit bump of src/loggregator`))
+			Expect(session.Out).To(gbytes.Say(`Submodule src/loggregator`))
+			Expect(session.Out).To(gbytes.Say(`> Knit bump of src/github.com/cloudfoundry/noaa`))
 		})
 
 		It("does not print any logs when --quiet flag is provided", func() {
@@ -79,6 +87,9 @@ var _ = Describe("Apply Patches", func() {
 			Eventually(session).Should(gexec.Exit(0))
 			Expect(session.Out).NotTo(gbytes.Say(`Knit patch of src/loggregator`))
 			Expect(session.Out).NotTo(gbytes.Say(`Knit bump of src/uaa-release`))
+			Expect(session.Out).NotTo(gbytes.Say(`Submodule src/uaa-release`))
+			Expect(session.Out).NotTo(gbytes.Say(`> Create final release 11.3`))
+			Expect(session.Out).NotTo(gbytes.Say(`> Bump UAA to 3.3.0.3`))
 			Expect(session.Out).NotTo(gbytes.Say(`Knit patch of src/capi-release/src/cloud_controller_ng`))
 			Expect(session.Out).NotTo(gbytes.Say(`Knit patch of src/capi-release/src/cloud_controller_ng`))
 			Expect(session.Out).NotTo(gbytes.Say(`Knit bump of src/consul-release`))
@@ -87,6 +98,11 @@ var _ = Describe("Apply Patches", func() {
 			Expect(session.Out).NotTo(gbytes.Say(`Knit patch of src/capi-release/src/cloud_controller_ng`))
 			Expect(session.Out).NotTo(gbytes.Say(`Knit patch of src/capi-release`))
 			Expect(session.Out).NotTo(gbytes.Say(`Update nginx to 1.11.1`))
+			Expect(session.Out).NotTo(gbytes.Say(`Knit patch of src/loggregator`))
+			Expect(session.Out).NotTo(gbytes.Say(`Knit patch of src/loggregator`))
+			Expect(session.Out).NotTo(gbytes.Say(`Knit bump of src/loggregator`))
+			Expect(session.Out).NotTo(gbytes.Say(`Submodule src/loggregator`))
+			Expect(session.Out).NotTo(gbytes.Say(`> Knit bump of src/github.com/cloudfoundry/noaa`))
 		})
 	})
 

--- a/main_test.go
+++ b/main_test.go
@@ -21,7 +21,7 @@ var _ = Describe("Apply Patches", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Eventually(session, "10s").Should(gexec.Exit(0))
 
-			command = exec.Command("git", "branch", "-D", "1.6.15")
+			command = exec.Command("git", "branch", "-D", "1.7.13")
 			command.Dir = releaseRepo
 			session, err = gexec.Start(command, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
@@ -32,7 +32,7 @@ var _ = Describe("Apply Patches", func() {
 			command := exec.Command(patcher,
 				"-repository-to-patch", releaseRepo,
 				"-patch-repository", patchesRepo,
-				"-version", "1.6.15")
+				"-version", "1.7.13")
 			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
 			Eventually(session, "10m").Should(gexec.Exit(0))
@@ -45,21 +45,25 @@ var _ = Describe("Apply Patches", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(session, "30s").Should(gexec.Exit(0))
-			Expect(session.Out).To(gbytes.Say("On branch 1.6.15"))
+			Expect(session.Out).To(gbytes.Say("On branch 1.7.13"))
 			Expect(session.Out).To(gbytes.Say("nothing to commit"))
 
-			command = exec.Command("git", "log", "--pretty=format:%s", "-n", "8")
+			command = exec.Command("git", "log", "--pretty=format:%s", "-n", "10")
 			command.Dir = releaseRepo
 			session, err = gexec.Start(command, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(session).Should(gexec.Exit(0))
-			Expect(session.Out).To(gbytes.Say(`Knit bump of src/uaa`))
-			Expect(session.Out).To(gbytes.Say(`Knit bump of src/etcd-release`))
+			Expect(session.Out).To(gbytes.Say(`Knit patch of src/loggregator`))
+			Expect(session.Out).To(gbytes.Say(`Knit bump of src/uaa-release`))
+			Expect(session.Out).To(gbytes.Say(`Knit patch of src/capi-release/src/cloud_controller_ng`))
+			Expect(session.Out).To(gbytes.Say(`Knit patch of src/capi-release/src/cloud_controller_ng`))
 			Expect(session.Out).To(gbytes.Say(`Knit bump of src/consul-release`))
-			Expect(session.Out).To(gbytes.Say(`add golang 1\.5\.3 to main blobs\.yml, needed by new consul release.*`))
-			Expect(session.Out).To(gbytes.Say(`Knit patch of src/uaa`))
-			Expect(session.Out).To(gbytes.Say(`Knit patch of src/uaa`))
+			Expect(session.Out).To(gbytes.Say(`Bump src/consul-release`))
+			Expect(session.Out).To(gbytes.Say(`Knit patch of src/github.com/cloudfoundry/gorouter`))
+			Expect(session.Out).To(gbytes.Say(`Knit patch of src/capi-release/src/cloud_controller_ng`))
+			Expect(session.Out).To(gbytes.Say(`Knit patch of src/capi-release`))
+			Expect(session.Out).To(gbytes.Say(`Update nginx to 1.11.1`))
 		})
 
 		It("does not print any logs when --quiet flag is provided", func() {
@@ -67,18 +71,22 @@ var _ = Describe("Apply Patches", func() {
 				"-repository-to-patch", releaseRepo,
 				"-patch-repository", patchesRepo,
 				"-quiet",
-				"-version", "1.6.15")
+				"-version", "1.7.13")
 			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
 			Eventually(session, "10m").Should(gexec.Exit(0))
 
 			Eventually(session).Should(gexec.Exit(0))
-			Expect(session.Out).NotTo(gbytes.Say(`Knit bump of src/uaa`))
-			Expect(session.Out).NotTo(gbytes.Say(`Knit bump of src/etcd-release`))
+			Expect(session.Out).NotTo(gbytes.Say(`Knit patch of src/loggregator`))
+			Expect(session.Out).NotTo(gbytes.Say(`Knit bump of src/uaa-release`))
+			Expect(session.Out).NotTo(gbytes.Say(`Knit patch of src/capi-release/src/cloud_controller_ng`))
+			Expect(session.Out).NotTo(gbytes.Say(`Knit patch of src/capi-release/src/cloud_controller_ng`))
 			Expect(session.Out).NotTo(gbytes.Say(`Knit bump of src/consul-release`))
-			Expect(session.Out).NotTo(gbytes.Say(`add golang 1\.5\.3 to main blobs\.yml, needed by new consul release.*`))
-			Expect(session.Out).NotTo(gbytes.Say(`Knit patch of src/uaa`))
-			Expect(session.Out).NotTo(gbytes.Say(`Knit patch of src/uaa`))
+			Expect(session.Out).NotTo(gbytes.Say(`Bump src/consul-release`))
+			Expect(session.Out).NotTo(gbytes.Say(`Knit patch of src/github.com/cloudfoundry/gorouter`))
+			Expect(session.Out).NotTo(gbytes.Say(`Knit patch of src/capi-release/src/cloud_controller_ng`))
+			Expect(session.Out).NotTo(gbytes.Say(`Knit patch of src/capi-release`))
+			Expect(session.Out).NotTo(gbytes.Say(`Update nginx to 1.11.1`))
 		})
 	})
 

--- a/patcher/command_runner.go
+++ b/patcher/command_runner.go
@@ -7,8 +7,9 @@ import (
 )
 
 type Command struct {
-	Args []string
-	Dir  string
+	Args       []string
+	Dir        string
+	Executable string
 }
 
 type CommandRunner struct {
@@ -55,6 +56,10 @@ func (r CommandRunner) Run(command Command) error {
 		Dir:    command.Dir,
 		Stdout: r.Stdout,
 		Stderr: r.Stderr,
+	}
+
+	if command.Executable != "" {
+		cmd.Path = command.Executable
 	}
 
 	err := cmd.Run()

--- a/patcher/repo.go
+++ b/patcher/repo.go
@@ -17,18 +17,20 @@ type commandRunner interface {
 }
 
 type Repo struct {
-	runner         commandRunner
-	repo           string
-	committerName  string
-	committerEmail string
+	runner            commandRunner
+	repo              string
+	committerName     string
+	committerEmail    string
+	commitMessagePath string
 }
 
 func NewRepo(commandRunner commandRunner, repo string, committerName, committerEmail string) Repo {
 	return Repo{
-		runner:         commandRunner,
-		repo:           repo,
-		committerName:  committerName,
-		committerEmail: committerEmail,
+		runner:            commandRunner,
+		repo:              repo,
+		committerName:     committerName,
+		committerEmail:    committerEmail,
+		commitMessagePath: filepath.Join(os.TempDir(), "knit-submodule-commit-message"),
 	}
 }
 
@@ -166,19 +168,41 @@ func (r Repo) BumpSubmodule(path, sha string) error {
 			Dir:  pathToRepo,
 		},
 		Command{
-			Args: []string{"commit", "-m", fmt.Sprintf("Knit bump of %s", path), "--no-verify"},
+			Args:       []string{"-c", fmt.Sprintf("echo \"Knit bump of %s\n\" > %s", path, r.commitMessagePath)},
+			Dir:        pathToRepo,
+			Executable: "/bin/bash",
+		},
+		Command{
+			Args:       []string{"-c", "git --no-pager diff --staged --submodule >> " + r.commitMessagePath},
+			Dir:        pathToRepo,
+			Executable: "/bin/bash",
+		},
+		Command{
+			Args: []string{"commit", "-F", r.commitMessagePath, "--no-verify"},
 			Dir:  pathToRepo,
 		},
 	}
 
 	if len(matches) == 3 {
-		commands = append(commands, Command{
-			Args: []string{"add", "-A", matches[1]},
-			Dir:  r.repo,
-		}, Command{
-			Args: []string{"commit", "-m", fmt.Sprintf("Knit bump of %s", matches[1]), "--no-verify"},
-			Dir:  r.repo,
-		})
+		commands = append(commands,
+			Command{
+				Args: []string{"add", "-A", matches[1]},
+				Dir:  r.repo,
+			},
+			Command{
+				Args:       []string{"-c", fmt.Sprintf("echo \"Knit bump of %s\n\" > %s", matches[1], r.commitMessagePath)},
+				Dir:        pathToRepo,
+				Executable: "/bin/bash",
+			},
+			Command{
+				Args:       []string{"-c", "git --no-pager diff --staged --submodule >> " + r.commitMessagePath},
+				Dir:        r.repo,
+				Executable: "/bin/bash",
+			},
+			Command{
+				Args: []string{"commit", "-F", r.commitMessagePath, "--no-verify"},
+				Dir:  r.repo,
+			})
 	}
 
 	for _, command := range commands {

--- a/patcher/repo_test.go
+++ b/patcher/repo_test.go
@@ -246,7 +246,17 @@ var _ = Describe("Repo", func() {
 					Dir:  repoPath,
 				},
 				patcher.Command{
-					Args: []string{"commit", "-m", "Knit bump of src/some/path", "--no-verify"},
+					Args:       []string{"-c", "echo \"Knit bump of src/some/path\n\" > " + filepath.Join(os.TempDir(), "knit-submodule-commit-message")},
+					Dir:        repoPath,
+					Executable: "/bin/bash",
+				},
+				patcher.Command{
+					Args:       []string{"-c", "git --no-pager diff --staged --submodule >> " + filepath.Join(os.TempDir(), "knit-submodule-commit-message")},
+					Dir:        repoPath,
+					Executable: "/bin/bash",
+				},
+				patcher.Command{
+					Args: []string{"commit", "-F", filepath.Join(os.TempDir(), "knit-submodule-commit-message"), "--no-verify"},
 					Dir:  repoPath,
 				},
 			}))
@@ -286,15 +296,35 @@ var _ = Describe("Repo", func() {
 					Dir:  filepath.Join(repoPath, "src/some/path"),
 				},
 				patcher.Command{
-					Args: []string{"commit", "-m", "Knit bump of src/some/other/path", "--no-verify"},
-					Dir:  filepath.Join(repoPath, "src/some/path"),
+					Args:       []string{"-c", "echo \"Knit bump of src/some/other/path\n\" > " + filepath.Join(os.TempDir(), "knit-submodule-commit-message")},
+					Dir:        filepath.Join(repoPath, "src", "some", "path"),
+					Executable: "/bin/bash",
+				},
+				patcher.Command{
+					Args:       []string{"-c", "git --no-pager diff --staged --submodule >> " + filepath.Join(os.TempDir(), "knit-submodule-commit-message")},
+					Dir:        filepath.Join(repoPath, "src", "some", "path"),
+					Executable: "/bin/bash",
+				},
+				patcher.Command{
+					Args: []string{"commit", "-F", filepath.Join(os.TempDir(), "knit-submodule-commit-message"), "--no-verify"},
+					Dir:  filepath.Join(repoPath, "src", "some", "path"),
 				},
 				patcher.Command{
 					Args: []string{"add", "-A", "src/some/path"},
 					Dir:  repoPath,
 				},
 				patcher.Command{
-					Args: []string{"commit", "-m", "Knit bump of src/some/path", "--no-verify"},
+					Args:       []string{"-c", "echo \"Knit bump of src/some/path\n\" > " + filepath.Join(os.TempDir(), "knit-submodule-commit-message")},
+					Dir:        filepath.Join(repoPath, "src", "some", "path"),
+					Executable: "/bin/bash",
+				},
+				patcher.Command{
+					Args:       []string{"-c", "git --no-pager diff --staged --submodule >> " + filepath.Join(os.TempDir(), "knit-submodule-commit-message")},
+					Dir:        repoPath,
+					Executable: "/bin/bash",
+				},
+				patcher.Command{
+					Args: []string{"commit", "-F", filepath.Join(os.TempDir(), "knit-submodule-commit-message"), "--no-verify"},
 					Dir:  repoPath,
 				},
 			}))


### PR DESCRIPTION
This makes it a little easier to see what changes have been applied after running knit. It only shows commits from direct submodules and not from nested submodules (i.e. commit messages from cloud_controller_ng would show up when you run `git log` in capi-release but not in cf-release).

We also changed to the tests to apply the 1.7 patches to test out bumping nested submodules.

@mdelillo @traelrawls @aemengo 