### PR TITLE
Added better final versioning in knit

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -18,11 +19,12 @@ var buildVersion string
 
 func main() {
 	var (
-		releaseRepository string
-		patchesRepository string
-		version           string
-		quiet             bool
-		showBuildVersion  bool
+		releaseRepository    string
+		patchesRepository    string
+		version              string
+		resultingVersionFile string
+		quiet                bool
+		showBuildVersion     bool
 	)
 
 	flag.StringVar(&releaseRepository, "repository-to-patch", "", "")
@@ -30,6 +32,7 @@ func main() {
 	flag.StringVar(&version, "version", "", "")
 	flag.BoolVar(&quiet, "quiet", false, "")
 	flag.BoolVar(&showBuildVersion, "v", false, "")
+	flag.StringVar(&resultingVersionFile, "resulting-version-file", "", "file to write out a generated version of the repository you just knit")
 	flag.Parse()
 
 	if showBuildVersion {
@@ -82,6 +85,14 @@ func main() {
 	err = apply.Checkpoint(initialCheckpoint)
 	if err != nil {
 		log.Fatal(err)
+	}
+
+	if resultingVersionFile != "" {
+		matches := regexp.MustCompile(`v(.*)`).FindStringSubmatch(initialCheckpoint.ResultingVersion)
+		err = ioutil.WriteFile(resultingVersionFile, []byte(matches[1]), 0644)
+		if err != nil {
+			log.Fatal(err)
+		}
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -66,6 +66,25 @@ var _ = Describe("Apply Patches", func() {
 			Expect(session.Out).To(gbytes.Say(`Knit patch of src/uaa`))
 		})
 
+		It("creates a file with a generated version of the thing it patched", func() {
+			file, err := ioutil.TempFile("", "")
+			Expect(err).NotTo(HaveOccurred())
+
+			command := exec.Command(patcher,
+				"-repository-to-patch", cfReleaseRepo,
+				"-patch-repository", cfPatchesDir,
+				"-version", "1.6.15",
+				"-resulting-version-file", file.Name(),
+			)
+
+			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(session, "10m").Should(gexec.Exit(0))
+			resultingVersion, err := ioutil.ReadAll(file)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(resultingVersion)).To(Equal("225-1.6.15"))
+		})
+
 		It("does not print any logs when --quiet flag is provided", func() {
 			command := exec.Command(patcher,
 				"-repository-to-patch", cfReleaseRepo,

--- a/patcher/versions_parser.go
+++ b/patcher/versions_parser.go
@@ -3,9 +3,10 @@ package patcher
 import "fmt"
 
 type Checkpoint struct {
-	Changes     []Changeset
-	CheckoutRef string
-	FinalBranch string
+	Changes          []Changeset
+	CheckoutRef      string
+	FinalBranch      string
+	ResultingVersion string
 }
 
 type Changeset struct {
@@ -54,6 +55,7 @@ func (p VersionsParser) GetCheckpoint() (Checkpoint, error) {
 
 	checkpoint.CheckoutRef = versionsToApply[0].Ref
 	checkpoint.FinalBranch = p.version
+	checkpoint.ResultingVersion = fmt.Sprintf("%s-%s", versionsToApply[0].Ref, p.version)
 
 	return checkpoint, nil
 }

--- a/patcher/versions_parser_test.go
+++ b/patcher/versions_parser_test.go
@@ -84,8 +84,9 @@ var _ = Describe("VersionsParser", func() {
 						},
 					},
 				},
-				CheckoutRef: "v124",
-				FinalBranch: "1.9.2",
+				CheckoutRef:      "v124",
+				FinalBranch:      "1.9.2",
+				ResultingVersion: "v124-1.9.2",
 			}))
 
 			Expect(patchSet.VersionsToApplyForCall.Receives.Version).To(Equal("1.9.2"))
@@ -120,8 +121,9 @@ var _ = Describe("VersionsParser", func() {
 							SubmodulePatches: map[string][]string{},
 						},
 					},
-					CheckoutRef: "v124",
-					FinalBranch: "3.2.1+something.else",
+					CheckoutRef:      "v124",
+					FinalBranch:      "3.2.1+something.else",
+					ResultingVersion: "v124-3.2.1+something.else",
 				}))
 
 				Expect(patchSet.VersionsToApplyForCall.Receives.Version).To(Equal("3.2.1+something.else"))


### PR DESCRIPTION
- After knitting a release repo, knit will write an output file with a generated version of the repo it just knitted.
- The file will only be written if the "resulting-version-file" parameter is provided, which points to the path of the file.
- The version will be of the form (ref)-(ERT_version). So if we just knitted cf-release v225 in 1.6.51, the version will be "225-1.6.51".
- This will keep knitted artifacts unique in the build pipelines.
- It will play nicely with BOSH across upgrades: i.e., in case a version of 1.6 ERT and 1.7 ERT have the same set of patches, they will still inherently be assigned different versions.
- It will remove dependence on arbitrary semver resources in the
  pipeline, thus reducing pipeline size.