### PR TITLE
configure committer locally on each command

### DIFF
--- a/patcher/apply.go
+++ b/patcher/apply.go
@@ -7,7 +7,6 @@ type Apply struct {
 }
 
 type repository interface {
-	ConfigureCommitter() error
 	Checkout(checkoutRef string) error
 	CheckoutBranch(name string) error
 	ApplyPatch(patch string) error
@@ -24,12 +23,7 @@ func NewApply(repo repository) Apply {
 }
 
 func (a Apply) Checkpoint(checkpoint Checkpoint) error {
-	err := a.repo.ConfigureCommitter()
-	if err != nil {
-		return err
-	}
-
-	err = a.repo.Checkout(checkpoint.CheckoutRef)
+	err := a.repo.Checkout(checkpoint.CheckoutRef)
 	if err != nil {
 		return err
 	}

--- a/patcher/apply_test.go
+++ b/patcher/apply_test.go
@@ -56,13 +56,6 @@ var _ = Describe("Apply", func() {
 	})
 
 	Describe("Checkpoint", func() {
-		It("configures the git committer", func() {
-			err := apply.Checkpoint(checkpoint)
-			Expect(err).NotTo(HaveOccurred())
-
-			Expect(repo.ConfigureCommitterCall.Count).To(Equal(1))
-		})
-
 		It("checkouts the initial ref defined by the checkpoint", func() {
 			err := apply.Checkpoint(checkpoint)
 			Expect(err).NotTo(HaveOccurred())
@@ -123,22 +116,6 @@ var _ = Describe("Apply", func() {
 		})
 
 		Context("when an error occurs", func() {
-			Context("when configure committer fails", func() {
-				It("returns an error", func() {
-					repo.ConfigureCommitterCall.Returns.Error = errors.New("meow")
-
-					err := apply.Checkpoint(checkpoint)
-					Expect(err).To(MatchError("meow"))
-
-					Expect(repo.CheckoutCall.Receives.Ref).To(BeEmpty())
-					Expect(repo.CheckoutBranchCall.Receives.Name).To(Equal(""))
-					Expect(repo.ApplyPatchCall.Receives.Patches).To(BeEmpty())
-					Expect(repo.AddSubmoduleCall.Receives.Submodules).To(BeEmpty())
-					Expect(repo.BumpSubmoduleCall.Receives.Submodules).To(BeEmpty())
-					Expect(repo.PatchSubmoduleCall.Receives.Paths).To(BeEmpty())
-				})
-			})
-
 			Context("when checkout fails", func() {
 				It("returns an error", func() {
 					repo.CheckoutCall.Returns.Error = errors.New("meow")

--- a/patcher/fakes/repository.go
+++ b/patcher/fakes/repository.go
@@ -3,13 +3,6 @@ package fakes
 import "github.com/pivotal-cf-experimental/knit/patcher"
 
 type Repository struct {
-	ConfigureCommitterCall struct {
-		Count   int
-		Returns struct {
-			Error error
-		}
-	}
-
 	CheckoutCall struct {
 		Receives struct {
 			Ref string
@@ -73,12 +66,6 @@ type Repository struct {
 			Error error
 		}
 	}
-}
-
-func (r *Repository) ConfigureCommitter() error {
-	r.ConfigureCommitterCall.Count++
-
-	return r.ConfigureCommitterCall.Returns.Error
 }
 
 func (r *Repository) Checkout(checkoutRef string) error {

--- a/patcher/repo.go
+++ b/patcher/repo.go
@@ -35,27 +35,6 @@ func NewRepo(commandRunner commandRunner, repo string, committerName, committerE
 	}
 }
 
-func (r Repo) ConfigureCommitter() error {
-	commands := []Command{
-		Command{
-			Args: []string{"config", "--global", "user.name", r.committerName},
-			Dir:  r.repo,
-		},
-		Command{
-			Args: []string{"config", "--global", "user.email", r.committerEmail},
-			Dir:  r.repo,
-		},
-	}
-
-	for _, command := range commands {
-		if err := r.runner.Run(command); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
 func (r Repo) Checkout(checkoutRef string) error {
 	commands := []Command{
 		Command{
@@ -147,8 +126,14 @@ func (r Repo) AddSubmodule(path, url, ref, branch string) error {
 			Dir:  r.repo,
 		},
 		Command{
-			Args: []string{"commit", "-m", fmt.Sprintf("Knit addition of %s", path), "--no-verify"},
-			Dir:  r.repo,
+			Args: []string{
+				"-c", fmt.Sprintf("user.name=%s", r.committerName),
+				"-c", fmt.Sprintf("user.email=%s", r.committerEmail),
+				"commit",
+				"-m", fmt.Sprintf("Knit addition of %s", path),
+				"--no-verify",
+			},
+			Dir: r.repo,
 		},
 	}
 
@@ -175,8 +160,14 @@ func (r Repo) RemoveSubmodule(path string) error {
 			Dir:  r.repo,
 		},
 		Command{
-			Args: []string{"commit", "-m", fmt.Sprintf("Knit removal of submodule '%s'", path), "--no-verify"},
-			Dir:  r.repo,
+			Args: []string{
+				"-c", fmt.Sprintf("user.name=%s", r.committerName),
+				"-c", fmt.Sprintf("user.email=%s", r.committerEmail),
+				"commit",
+				"-m", fmt.Sprintf("Knit removal of submodule '%s'", path),
+				"--no-verify",
+			},
+			Dir: r.repo,
 		},
 	}
 
@@ -234,8 +225,14 @@ func (r Repo) BumpSubmodule(path, sha string) error {
 			Dir:  pathToRepo,
 		},
 		Command{
-			Args: []string{"commit", "-m", fmt.Sprintf("Knit bump of %s", path), "--no-verify"},
-			Dir:  pathToRepo,
+			Args: []string{
+				"-c", fmt.Sprintf("user.name=%s", r.committerName),
+				"-c", fmt.Sprintf("user.email=%s", r.committerEmail),
+				"commit",
+				"-m", fmt.Sprintf("Knit bump of %s", path),
+				"--no-verify",
+			},
+			Dir: pathToRepo,
 		},
 	}
 
@@ -244,8 +241,14 @@ func (r Repo) BumpSubmodule(path, sha string) error {
 			Args: []string{"add", "-A", matches[1]},
 			Dir:  r.repo,
 		}, Command{
-			Args: []string{"commit", "-m", fmt.Sprintf("Knit bump of %s", matches[1]), "--no-verify"},
-			Dir:  r.repo,
+			Args: []string{
+				"-c", fmt.Sprintf("user.name=%s", r.committerName),
+				"-c", fmt.Sprintf("user.email=%s", r.committerEmail),
+				"commit",
+				"-m", fmt.Sprintf("Knit bump of %s", matches[1]),
+				"--no-verify",
+			},
+			Dir: r.repo,
 		})
 	}
 
@@ -284,8 +287,14 @@ func (r Repo) PatchSubmodule(path, fullPathToPatch string) error {
 				Dir:  absoluteSubmodulePath,
 			},
 			Command{
-				Args: []string{"commit", "-m", fmt.Sprintf("Knit submodule patch of %s", submodulePath), "--no-verify"},
-				Dir:  absoluteSubmodulePath,
+				Args: []string{
+					"-c", fmt.Sprintf("user.name=%s", r.committerName),
+					"-c", fmt.Sprintf("user.email=%s", r.committerEmail),
+					"commit",
+					"-m", fmt.Sprintf("Knit submodule patch of %s", submodulePath),
+					"--no-verify",
+				},
+				Dir: absoluteSubmodulePath,
 			},
 		}
 
@@ -302,8 +311,14 @@ func (r Repo) PatchSubmodule(path, fullPathToPatch string) error {
 			Dir:  r.repo,
 		},
 		Command{
-			Args: []string{"commit", "-m", fmt.Sprintf("Knit patch of %s", path), "--no-verify"},
-			Dir:  r.repo,
+			Args: []string{
+				"-c", fmt.Sprintf("user.name=%s", r.committerName),
+				"-c", fmt.Sprintf("user.email=%s", r.committerEmail),
+				"commit",
+				"-m", fmt.Sprintf("Knit patch of %s", path),
+				"--no-verify",
+			},
+			Dir: r.repo,
 		},
 	}
 

--- a/patcher/repo_test.go
+++ b/patcher/repo_test.go
@@ -16,9 +16,10 @@ import (
 
 var _ = Describe("Repo", func() {
 	var (
-		runner   *fakes.CommandRunner
-		repoPath string
-		r        patcher.Repo
+		runner      *fakes.CommandRunner
+		repoPath    string
+		r           patcher.Repo
+		user, email string
 	)
 
 	BeforeEach(func() {
@@ -33,41 +34,14 @@ var _ = Describe("Repo", func() {
 			Expect(err).NotTo(HaveOccurred())
 		}
 
-		r = patcher.NewRepo(runner, repoPath, "testbot", "foo@example.com")
+		user = "testbot"
+		email = "foo@example.com"
+		r = patcher.NewRepo(runner, repoPath, user, email)
 	})
 
 	AfterEach(func() {
 		err := os.RemoveAll(repoPath)
 		Expect(err).NotTo(HaveOccurred())
-	})
-
-	Describe("ConfigureCommitter", func() {
-		It("sets the git committer name and email", func() {
-			err := r.ConfigureCommitter()
-			Expect(err).NotTo(HaveOccurred())
-
-			Expect(runner.RunCall.Receives.Commands).To(Equal([]patcher.Command{
-				patcher.Command{
-					Args: []string{"config", "--global", "user.name", "testbot"},
-					Dir:  repoPath,
-				},
-				patcher.Command{
-					Args: []string{"config", "--global", "user.email", "foo@example.com"},
-					Dir:  repoPath,
-				},
-			}))
-		})
-
-		Context("failure cases", func() {
-			Context("when a config command fails", func() {
-				It("returns an error", func() {
-					runner.RunCall.Returns.Errors = []error{nil, errors.New("some error")}
-					err := r.ConfigureCommitter()
-					Expect(runner.RunCall.Count).To(Equal(2))
-					Expect(err).To(MatchError("some error"))
-				})
-			})
-		})
 	})
 
 	Describe("Checkout", func() {
@@ -172,8 +146,14 @@ var _ = Describe("Repo", func() {
 					Dir:  repoPath,
 				},
 				patcher.Command{
-					Args: []string{"commit", "-m", "Knit addition of src/some/path", "--no-verify"},
-					Dir:  repoPath,
+					Args: []string{
+						"-c", fmt.Sprintf("user.name=%s", user),
+						"-c", fmt.Sprintf("user.email=%s", email),
+						"commit",
+						"-m", "Knit addition of src/some/path",
+						"--no-verify",
+					},
+					Dir: repoPath,
 				},
 			}))
 		})
@@ -212,8 +192,14 @@ var _ = Describe("Repo", func() {
 						Dir:  repoPath,
 					},
 					patcher.Command{
-						Args: []string{"commit", "-m", "Knit addition of src/some/path", "--no-verify"},
-						Dir:  repoPath,
+						Args: []string{
+							"-c", fmt.Sprintf("user.name=%s", user),
+							"-c", fmt.Sprintf("user.email=%s", email),
+							"commit",
+							"-m", "Knit addition of src/some/path",
+							"--no-verify",
+						},
+						Dir: repoPath,
 					},
 				}))
 			})
@@ -244,8 +230,14 @@ var _ = Describe("Repo", func() {
 					Dir:  repoPath,
 				},
 				patcher.Command{
-					Args: []string{"commit", "-m", "Knit removal of submodule 'src/some/path'", "--no-verify"},
-					Dir:  repoPath,
+					Args: []string{
+						"-c", fmt.Sprintf("user.name=%s", user),
+						"-c", fmt.Sprintf("user.email=%s", email),
+						"commit",
+						"-m", "Knit removal of submodule 'src/some/path'",
+						"--no-verify",
+					},
+					Dir: repoPath,
 				},
 			}))
 		})
@@ -300,8 +292,14 @@ var _ = Describe("Repo", func() {
 					Dir:  repoPath,
 				},
 				patcher.Command{
-					Args: []string{"commit", "-m", "Knit bump of src/some/path", "--no-verify"},
-					Dir:  repoPath,
+					Args: []string{
+						"-c", fmt.Sprintf("user.name=%s", user),
+						"-c", fmt.Sprintf("user.email=%s", email),
+						"commit",
+						"-m", "Knit bump of src/some/path",
+						"--no-verify",
+					},
+					Dir: repoPath,
 				},
 			}))
 		})
@@ -344,16 +342,28 @@ var _ = Describe("Repo", func() {
 					Dir:  filepath.Join(repoPath, "src/some/path"),
 				},
 				patcher.Command{
-					Args: []string{"commit", "-m", "Knit bump of src/some/other/path", "--no-verify"},
-					Dir:  filepath.Join(repoPath, "src/some/path"),
+					Args: []string{
+						"-c", fmt.Sprintf("user.name=%s", user),
+						"-c", fmt.Sprintf("user.email=%s", email),
+						"commit",
+						"-m", "Knit bump of src/some/other/path",
+						"--no-verify",
+					},
+					Dir: filepath.Join(repoPath, "src/some/path"),
 				},
 				patcher.Command{
 					Args: []string{"add", "-A", "src/some/path"},
 					Dir:  repoPath,
 				},
 				patcher.Command{
-					Args: []string{"commit", "-m", "Knit bump of src/some/path", "--no-verify"},
-					Dir:  repoPath,
+					Args: []string{
+						"-c", fmt.Sprintf("user.name=%s", user),
+						"-c", fmt.Sprintf("user.email=%s", email),
+						"commit",
+						"-m", "Knit bump of src/some/path",
+						"--no-verify",
+					},
+					Dir: repoPath,
 				},
 			}))
 		})
@@ -391,8 +401,14 @@ var _ = Describe("Repo", func() {
 					Dir:  repoPath,
 				},
 				patcher.Command{
-					Args: []string{"commit", "-m", "Knit patch of src/different/path", "--no-verify"},
-					Dir:  repoPath,
+					Args: []string{
+						"-c", fmt.Sprintf("user.name=%s", user),
+						"-c", fmt.Sprintf("user.email=%s", email),
+						"commit",
+						"-m", "Knit patch of src/different/path",
+						"--no-verify",
+					},
+					Dir: repoPath,
 				},
 			}))
 		})
@@ -424,16 +440,28 @@ var _ = Describe("Repo", func() {
 						Dir:  filepath.Join(repoPath, "src/some/crazy/submodule"),
 					},
 					patcher.Command{
-						Args: []string{"commit", "-m", "Knit submodule patch of src/some/crazy/submodule", "--no-verify"},
-						Dir:  filepath.Join(repoPath, "src/some/crazy/submodule"),
+						Args: []string{
+							"-c", fmt.Sprintf("user.name=%s", user),
+							"-c", fmt.Sprintf("user.email=%s", email),
+							"commit",
+							"-m", "Knit submodule patch of src/some/crazy/submodule",
+							"--no-verify",
+						},
+						Dir: filepath.Join(repoPath, "src/some/crazy/submodule"),
 					},
 					patcher.Command{
 						Args: []string{"add", "-A", "."},
 						Dir:  repoPath,
 					},
 					patcher.Command{
-						Args: []string{"commit", "-m", "Knit patch of src/different/path", "--no-verify"},
-						Dir:  repoPath,
+						Args: []string{
+							"-c", fmt.Sprintf("user.name=%s", user),
+							"-c", fmt.Sprintf("user.email=%s", email),
+							"commit",
+							"-m", "Knit patch of src/different/path",
+							"--no-verify",
+						},
+						Dir: repoPath,
 					},
 				}))
 			})


### PR DESCRIPTION
fixes #10

setting a global committer has the unfortunate side effect of changing
global state on a workstation. this change allows knit to continue
setting a custom user to commit with, but it is only set locally for
each git command.